### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
-#React + RxJS: going fully reactive
+# React + RxJS: going fully reactive
 
-###React is _not_ reactive
+### React is _not_ reactive
 
 Nowadays React is getting more and more popular. However, despite the name, it is **not** fully reactive solution. As Andre Staltz says - [only rendering is reacitve in React](http://staltz.com/dont-react/#/12). But can we change that? Can we make a react components _more_ reactive?
 
-###Going reactive in the component
+### Going reactive in the component
 
 Imagine a simple counter written in plain, old React:
 ```js


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
